### PR TITLE
News Margin

### DIFF
--- a/themes/ra-theme/assets/css/summary.scss
+++ b/themes/ra-theme/assets/css/summary.scss
@@ -49,6 +49,9 @@ ul.summary {
       font-size: 18px;
       line-height: 1.2em;
       text-align: justify;
+      margin-right: 1rem;
+      hyphens: auto;
+
 
       @media (max-width: $summary-break) {
         text-align: left !important;


### PR DESCRIPTION
Add hyphen: auto to main div inside li for summary to fix text cliping with posts that contain long URLs
Add 1rem of margin right so summary text does not go all the way to the edge.