### PR TITLE
Remove ghost images on drag in carousels

### DIFF
--- a/layouts/videos/card.html
+++ b/layouts/videos/card.html
@@ -11,8 +11,8 @@
 
   {{ if not (eq $file "none") }}
     {{- $image := $file.Resize "400x" -}}
-      <a href="https://youtu.be/{{ $.Params.videoId }}" target="_blank">
-        <img src="{{ $image.Permalink }}" alt="{{ $.Title }}">
+      <a href="https://youtu.be/{{ $.Params.videoId }}" target="_blank" draggable="false">
+        <img src="{{ $image.Permalink }}" alt="{{ $.Title }}" draggable="false">
       </a>
   {{- else -}}
     {{ warnf "No thumbnail found for video-card %s" .Title }}

--- a/themes/ra-theme/layouts/testimonials/quote-box.html
+++ b/themes/ra-theme/layouts/testimonials/quote-box.html
@@ -8,10 +8,10 @@
     {{- with $.Page.Params.rotation -}}
       {{- $sizing = printf "%s r%d" $sizing . -}}
     {{- end -}}
-    <img src="{{ (.Resize $sizing).Permalink }}" alt="{{ .Name }}">
+    <img src="{{ (.Resize $sizing).Permalink }}" alt="{{ .Name }}" draggable="false">
   {{ else }}
     {{ warnf "No profile image found for %s" .File }}
-    <img src="{{ ((resources.Get "images/anon-profile.png").Resize "200x").Permalink }}" alt="Photo missing.">
+    <img src="{{ ((resources.Get "images/anon-profile.png").Resize "200x").Permalink }}" alt="Photo missing." draggable="false">
   {{ end }}
   <div>
     {{ .Content }}


### PR DESCRIPTION
Add the draggable attribute to all img and anchor tags in carousels and set it to false.
This prevents the urls in anchor tags and images in img tags from being dragged out into
ghost images and preventing the swiping functionality on desktop when user clicks on the image
with a mouse to drag.